### PR TITLE
Update Docker base image to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM docker:stable
+FROM docker:latest
 
 COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
+


### PR DESCRIPTION
Without this, we're getting

```
docker run --detach --name rabbitmq --publish 5672:5672 rabbitmq:3.8.9
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
See 'docker run --help'.
```